### PR TITLE
feat: support error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,41 @@ serve(app, ({ port }) => {
 });
 ```
 
+### Error Handling
+
+You can use `signal` in `getContext` to handle error
+
+```ts
+workflow.handle([convertEvent], () => {
+  const { signal } = getContext();
+
+  signal.onabort = () => {
+    console.error("error in convert event:", abort.reason);
+  };
+});
+```
+
+### Pitfall in **browser**
+
+You must call `getContext()` in the top level of the workflow, otherwise we will lose the async context of the workflow.
+
+```ts
+workflow.handle([startEvent], async () => {
+  const { stream } = getContext(); // ✅ this is ok
+  await fetchData();
+});
+
+workflow.handle([startEvent], async () => {
+  await fetchData();
+  const { stream } = getContext(); // ❌ this is not ok
+  // we have no way to know this code was originally part of the workflow
+  // w/o AsyncContext
+});
+```
+
+Due to missing API of `async_hooks` in browser, we are looking
+for [Async Context](https://github.com/tc39/proposal-async-context) to solve this problem in the future.
+
 # LICENSE
 
 MIT

--- a/packages/fluere/src/core/internal/context.ts
+++ b/packages/fluere/src/core/internal/context.ts
@@ -3,6 +3,7 @@ import type { WorkflowEventData } from "../event";
 
 export type Context = {
   get stream(): ReadableStream<WorkflowEventData<any>>;
+  get signal(): AbortSignal;
   sendEvent: (event: WorkflowEventData<any>) => void;
 };
 

--- a/packages/fluere/src/core/internal/executor.ts
+++ b/packages/fluere/src/core/internal/executor.ts
@@ -5,6 +5,7 @@ import { _executorAsyncLocalStorage, type Context } from "./context";
 import { createAsyncContext } from "fluere/async-context";
 
 type HandlerContext = {
+  abortController: AbortController;
   handler: Handler<WorkflowEvent<any>[], any>;
   inputs: WorkflowEventData<any>[];
   outputs: WorkflowEventData<any>[];
@@ -32,7 +33,14 @@ export const createContext = ({ listeners }: ExecutorParams): Context => {
     handler: Handler<WorkflowEvent<any>[], any>,
     inputs: WorkflowEventData<any>[],
   ) => {
+    let handlerAbortController: AbortController;
     const handlerContext: HandlerContext = {
+      get abortController() {
+        if (!handlerAbortController) {
+          handlerAbortController = new AbortController();
+        }
+        return handlerAbortController;
+      },
       handler,
       inputs,
       outputs: [],
@@ -41,9 +49,18 @@ export const createContext = ({ listeners }: ExecutorParams): Context => {
     };
     handlerContext.prev.next.add(handlerContext);
     handlerContextAsyncLocalStorage.run(handlerContext, () => {
-      const result = _executorAsyncLocalStorage.run(context, () =>
-        handler(...inputs),
-      );
+      const result = _executorAsyncLocalStorage.run(context, () => {
+        try {
+          return handler(...inputs);
+        } catch (error) {
+          if (handlerAbortController ?? rootAbortController) {
+            (handlerAbortController ?? rootAbortController).abort(error);
+          } else {
+            console.error("unhandled error in handler", error);
+            throw error;
+          }
+        }
+      });
       // return value is a special event
       if (isPromiseLike(result)) {
         result.then((event) => {
@@ -93,6 +110,11 @@ export const createContext = ({ listeners }: ExecutorParams): Context => {
         },
       });
     },
+    get signal() {
+      const context =
+        handlerContextAsyncLocalStorage.getStore() ?? handlerRootContext;
+      return context.abortController.signal;
+    },
     sendEvent: (event) => {
       const context =
         handlerContextAsyncLocalStorage.getStore() ?? handlerRootContext;
@@ -104,7 +126,14 @@ export const createContext = ({ listeners }: ExecutorParams): Context => {
     },
   };
 
+  let rootAbortController = new AbortController();
   const handlerRootContext: HandlerContext = {
+    get abortController() {
+      if (!rootAbortController) {
+        rootAbortController = new AbortController();
+      }
+      return rootAbortController;
+    },
     inputs: [],
     outputs: [],
     handler: null!,

--- a/packages/fluere/src/core/workflow.ts
+++ b/packages/fluere/src/core/workflow.ts
@@ -10,7 +10,7 @@ export type Workflow<Start, Stop> = {
   >(
     accept: AcceptEvents,
     handler: Handler<AcceptEvents, Result>,
-  ): void;
+  ): HandlerRef<AcceptEvents, Result>;
 
   get startEvent(): WorkflowEvent<Start>;
   get stopEvent(): WorkflowEvent<Stop>;

--- a/packages/fluere/tests/abort-signal.spec.ts
+++ b/packages/fluere/tests/abort-signal.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test, vi } from "vitest";
+import { createWorkflow, getContext, workflowEvent } from "fluere";
+
+describe("abort signal", () => {
+  test("basic", () => {
+    const startEvent = workflowEvent();
+    const stopEvent = workflowEvent();
+    const workflow = createWorkflow({
+      startEvent,
+      stopEvent,
+    });
+
+    const err = new Error("1");
+    workflow.handle([startEvent], () => {
+      throw err;
+    });
+    {
+      const { sendEvent, signal } = workflow.createContext();
+      signal.onabort = vi.fn(() => {
+        expect(signal.reason).toBe(err);
+      });
+      sendEvent(startEvent());
+      expect(signal.onabort).toBeCalled();
+    }
+    {
+      const { sendEvent, signal } = workflow.createContext();
+      signal.onabort = vi.fn(() => {
+        expect(signal.reason).toBe(err);
+      });
+      sendEvent(startEvent());
+      expect(signal.onabort).toBeCalled();
+    }
+  });
+
+  test("only inner signal called", () => {
+    const startEvent = workflowEvent();
+    const stopEvent = workflowEvent();
+    const workflow = createWorkflow({
+      startEvent,
+      stopEvent,
+    });
+
+    const err = new Error("1");
+    let handlerSignal: AbortSignal;
+    workflow.handle([startEvent], () => {
+      const { signal } = getContext();
+      handlerSignal = signal;
+      signal.onabort = vi.fn(() => {
+        expect(signal.reason).toBe(err);
+      });
+      throw err;
+    });
+
+    const { sendEvent, signal } = workflow.createContext();
+    signal.onabort = vi.fn(() => {
+      expect(signal.reason).toBe(err);
+    });
+    sendEvent(startEvent());
+    expect(signal.onabort).not.toBeCalled();
+    expect(handlerSignal!.onabort).toBeCalled();
+  });
+});


### PR DESCRIPTION
You can use `signal` in `getContext` to handle error

```ts
workflow.handle([convertEvent], () => {
  const { signal } = getContext();

  signal.onabort = () => {
    console.error("error in convert event:", abort.reason);
  };
});
```